### PR TITLE
fixed error in tokenization code for other datasets in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ def bert_uncased_tokenize(fin, fout):
     tok = BertTokenizer.from_pretrained('bert-base-uncased')
     for line in fin:
         word_pieces = tok.tokenize(line.strip())
-        new_line = " ".join(new)
+        new_line = " ".join(word_pieces)
         fout.write('{}\n'.format(new_line))
 bert_uncased_tokenize('train.src', 'tokenized_train.src')
 bert_uncased_tokenize('train.tgt', 'tokenized_train.tgt')


### PR DESCRIPTION
In this code sample in the README which helps users tokenize their own data, there is a variable used `new`, which is not defined in the scope of the function. I believe the intended variable to be used is `word_pieces`.