### PR TITLE
Update fix for ngram_criterions.py and bert_dictionary.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+.vscode/

--- a/src/prophetnet/bert_dictionary.py
+++ b/src/prophetnet/bert_dictionary.py
@@ -25,7 +25,7 @@ class BertDictionary(Dictionary):
         bos='<s>',
         extra_special_symbols=None,
     ):
-        super().__init__(pad, eos, unk, bos, extra_special_symbols)
+        super().__init__(pad=pad, eos=eos, unk=unk, bos=bos, extra_special_symbols=extra_special_symbols)
 
     @classmethod
     def load_from_file(cls, filename):

--- a/src/prophetnet/ngram_criterions.py
+++ b/src/prophetnet/ngram_criterions.py
@@ -10,10 +10,10 @@ import torch.nn.functional as F
 
 from fairseq import utils
 
-from fairseq.criterions import FairseqCriterion, register_criterion 
+from fairseq.criterions import LegacyFairseqCriterion, register_criterion 
 
 @register_criterion('ngram_language_loss')
-class NgramLmLoss(FairseqCriterion):
+class NgramLmLoss(LegacyFairseqCriterion):
     """
     Implementation for the loss used in masked language model (MLM) training.
     """

--- a/xProphetNet/prophetnet/bert_dictionary.py
+++ b/xProphetNet/prophetnet/bert_dictionary.py
@@ -25,7 +25,7 @@ class BertDictionary(Dictionary):
         bos='<s>',
         extra_special_symbols=None,
     ):
-        super().__init__(pad, eos, unk, bos, extra_special_symbols)
+        super().__init__(pad=pad, eos=eos, unk=unk, bos=bos, extra_special_symbols=extra_special_symbols)
 
     @classmethod
     def load_from_file(cls, filename):

--- a/xProphetNet/prophetnet/ngram_criterions.py
+++ b/xProphetNet/prophetnet/ngram_criterions.py
@@ -10,10 +10,10 @@ import torch.nn.functional as F
 
 from fairseq import utils
 
-from fairseq.criterions import FairseqCriterion, register_criterion 
+from fairseq.criterions import LegacyFairseqCriterion, register_criterion 
 
 @register_criterion('ngram_language_loss')
-class NgramLmLoss(FairseqCriterion):
+class NgramLmLoss(LegacyFairseqCriterion):
     """
     Implementation for the loss used in masked language model (MLM) training.
     """


### PR DESCRIPTION
**_File bert_dictionary.py fix_** :- Since BertDictionary is inheriting Dictionary from fairseq.data just passing args to super will create problem cause there is * in Dictionary  class so have to pass args with specific keys

**_File ngram_criterions.py fix_** :- after facing error for   _NotImplementedError: Unable to infer Criterion arguments, please implement NgramLmLoss.build_criterion_ and checking this pr I have update code as per this pr
https://github.com/pytorch/fairseq/commit/f26c8ff69fc1f4c5c4091964439d1bdec7431acd